### PR TITLE
Add heap `extract` func, BinTreeNode updates, etc

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     testMatch: ['**/*.test.ts'],
-    verbose: true,
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "format": "eslint '*/**/*.{js,ts}' --fix",
         "lint": "eslint '*/**/*.{js,ts}' && tsc",
-        "test": "jest",
+        "test": "jest --verbose",
         "watch": "jest --watch"
     },
     "author": "Rob McGuire <robert.mcgui@gmail.com>",

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/BinTreeNode.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/BinTreeNode.ts
@@ -7,11 +7,10 @@ export const enum ChildType {
 // its parent node
 export default class BinTreeNode {
     value: number | string;
-    parent: BinTreeNode = null;
-    childType: ChildType = null;
 
-    private _leftChild: BinTreeNode;
-    private _rightChild: BinTreeNode;
+    private parent: BinTreeNode = null;
+    private leftChild: BinTreeNode;
+    private rightChild: BinTreeNode;
 
     constructor(
         value: number | string = null,
@@ -23,39 +22,76 @@ export default class BinTreeNode {
         this.setRightChild(rightChild);
     }
 
-    isChildless(): boolean {
-        return !this._leftChild && !this._rightChild;
+    // Return the parent. Don't allow it to be set directly.
+    getParent(): BinTreeNode {
+        return this.parent;
     }
 
-    // Renouce parents, become a man/woman
-    emancipate(): void {
-        this.parent = null;
-        this.childType = null;
-    }
-
-    // Left child node accessors
-    getLeftChild(): BinTreeNode {
-        return this._leftChild;
-    }
-
-    setLeftChild(newNode: BinTreeNode): void {
-        this._leftChild = newNode;
-        if (newNode) {
-            this._leftChild.parent = this;
-            this._leftChild.childType = ChildType.left;
+    // Dynamically return what kind of child this node is, if any
+    getChildType(): ChildType {
+        if (this.parent) {
+            if (this.parent.getLeftChild() === this) {
+                return ChildType.left;
+            } else if (this.parent.getRightChild() === this) {
+                return ChildType.right;
+            } else {
+                throw new Error(
+                    'Node has parent, but parent does not have child',
+                );
+            }
         }
+        return null;
     }
 
-    // Right child node accessors
+    // Get the left or right child node
+    getLeftChild(): BinTreeNode {
+        return this.leftChild;
+    }
     getRightChild(): BinTreeNode {
-        return this._rightChild;
+        return this.rightChild;
     }
 
-    setRightChild(newNode: BinTreeNode): void {
-        this._rightChild = newNode;
+    // Return if this node has any children
+    isChildless(): boolean {
+        return !this.leftChild && !this.rightChild;
+    }
+
+    // Adopt a new left or right child, or abandon it by passing `null`
+    setLeftChild(newNode: BinTreeNode): void {
         if (newNode) {
-            this._rightChild.parent = this;
-            this._rightChild.childType = ChildType.right;
+            newNode.parent = this;
+        } else if (this.leftChild) {
+            this.leftChild.parent = null;
+        }
+        this.leftChild = newNode;
+    }
+    setRightChild(newNode: BinTreeNode): void {
+        if (newNode) {
+            newNode.parent = this;
+        } else if (this.rightChild) {
+            this.rightChild.parent = null;
+        }
+        this.rightChild = newNode;
+    }
+
+    // Give up custody of both children if they exist
+    abandonChildren(): void {
+        this.setLeftChild(null);
+        this.setRightChild(null);
+    }
+
+    // Renouce parent if there is one, become a man/woman
+    emancipate(): void {
+        if (this.parent) {
+            if (this.getChildType() === ChildType.left) {
+                this.parent.setLeftChild(null);
+            } else if (this.getChildType() === ChildType.right) {
+                this.parent.setRightChild(null);
+            } else {
+                throw new Error(
+                    "This node has a parent, but can't determine child type",
+                );
+            }
         }
     }
 }

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/BinTreeNode.test.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/BinTreeNode.test.ts
@@ -1,101 +1,267 @@
+import { getBinTreeDisplayLines } from '../binTreeDisplay';
 import BinTreeNode, { ChildType, cn } from '../BinTreeNode';
 
 describe('BinTreeNode', () => {
-    it('has a value', () => {
-        const tree = new BinTreeNode('test-val');
-        expect(tree.value).toEqual('test-val');
-    });
-
-    it('has a value that defaults to null', () => {
-        const tree = new BinTreeNode();
-        expect(tree.value).toBeNull();
-    });
-
-    it('can have a left and a right node', () => {
-        const leftChild = new BinTreeNode('left-child');
-        const rightChild = new BinTreeNode('right-child');
-        const tree = new BinTreeNode('root', leftChild, rightChild);
-
-        expect(tree.getLeftChild()).toBe(leftChild);
-        expect(tree.getRightChild()).toBe(rightChild);
-    });
-
-    it('sets the parent node of the child nodes', () => {
-        const leftChild = new BinTreeNode('left-child');
-        const rightChild = new BinTreeNode('right-child');
-        const tree = new BinTreeNode('parent', leftChild, rightChild);
-
-        expect(leftChild.parent).toStrictEqual(tree);
-        expect(rightChild.parent).toStrictEqual(tree);
-    });
-
-    it('sets the parent node of the child node set after instantiation', () => {
-        const leftChild = new BinTreeNode('left-child');
-        const rightChild = new BinTreeNode('right-child');
-
-        const tree = new BinTreeNode('parent');
-        tree.setLeftChild(leftChild);
-        tree.setRightChild(rightChild);
-
-        expect(leftChild.parent).toStrictEqual(tree);
-        expect(rightChild.parent).toStrictEqual(tree);
-    });
-
-    it('can be emancipated', () => {
-        const child = new BinTreeNode('child');
-        const parent = new BinTreeNode('parent', child);
-
-        expect(child.parent).toStrictEqual(parent);
-        expect(child.childType).toStrictEqual(ChildType.left);
-
-        child.emancipate();
-
-        expect(child.parent).toBeNull();
-        expect(child.childType).toBeNull();
-    });
-
-    it('can become childless', () => {
-        const leftChild = new BinTreeNode('left-child');
-        const rightChild = new BinTreeNode('right-child');
-        const parent = new BinTreeNode('parent', leftChild, rightChild);
-
-        expect(parent.getLeftChild()).toStrictEqual(leftChild);
-        expect(parent.getRightChild()).toStrictEqual(rightChild);
-        expect(parent.isChildless()).toBe(false);
-
-        parent.setLeftChild(null);
-
-        expect(parent.isChildless()).toBe(false);
-
-        parent.setRightChild(null);
-
-        expect(parent.isChildless()).toBe(true);
-    });
-
-    describe('cn', () => {
-        it('creates a new BinTreeNode', () => {
-            const tree = cn('root', cn('left'), cn('right'));
-            expect(tree).toMatchInlineSnapshot(`
-                BinTreeNode {
-                  "_leftChild": BinTreeNode {
-                    "_leftChild": null,
-                    "_rightChild": null,
-                    "childType": 0,
-                    "parent": [Circular],
-                    "value": "left",
-                  },
-                  "_rightChild": BinTreeNode {
-                    "_leftChild": null,
-                    "_rightChild": null,
-                    "childType": 1,
-                    "parent": [Circular],
-                    "value": "right",
-                  },
-                  "childType": null,
-                  "parent": null,
-                  "value": "root",
-                }
+    describe('constructor', () => {
+        it('sets the value to null by default', () => {
+            const tree = new BinTreeNode();
+            expect(tree.value).toBeNull();
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "null",
+                ]
             `);
         });
+
+        it('can assign a value', () => {
+            const tree = new BinTreeNode('test-val');
+            expect(tree.value).toEqual('test-val');
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "test-val",
+                ]
+            `);
+        });
+
+        it('can set a left and a right node', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('root', leftChild, rightChild);
+
+            expect(tree.getLeftChild()).toBe(leftChild);
+            expect(tree.getRightChild()).toBe(rightChild);
+
+            expect(leftChild.getParent()).toStrictEqual(tree);
+            expect(leftChild.getChildType()).toEqual(ChildType.left);
+            expect(rightChild.getParent()).toStrictEqual(tree);
+            expect(rightChild.getChildType()).toEqual(ChildType.right);
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "root",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+        });
+    });
+
+    describe('setLeftChild, setRightChild', () => {
+        it('can adopt left and right children', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+
+            const tree = new BinTreeNode('parent');
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                ]
+            `);
+
+            tree.setLeftChild(leftChild);
+            tree.setRightChild(rightChild);
+
+            expect(tree.getLeftChild()).toBe(leftChild);
+            expect(tree.getRightChild()).toBe(rightChild);
+
+            expect(leftChild.getParent()).toStrictEqual(tree);
+            expect(leftChild.getChildType()).toEqual(ChildType.left);
+            expect(rightChild.getParent()).toStrictEqual(tree);
+            expect(rightChild.getChildType()).toEqual(ChildType.right);
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+        });
+
+        it('can abandon the left child', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild, rightChild);
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+
+            tree.setLeftChild(null);
+
+            expect(tree.getLeftChild()).toBe(null);
+
+            expect(leftChild.getParent()).toBeNull();
+            expect(leftChild.getChildType()).toBeNull();
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "└──[R] right-child",
+                ]
+            `);
+        });
+
+        it('can abandon the right child', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild, rightChild);
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+
+            tree.setRightChild(null);
+
+            expect(tree.getRightChild()).toBe(null);
+
+            expect(rightChild.getParent()).toBeNull();
+            expect(rightChild.getChildType()).toBeNull();
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "└──[L] left-child",
+                ]
+            `);
+        });
+    });
+
+    describe('isChildless', () => {
+        it('returns true if the node has no children', () => {
+            const tree = new BinTreeNode('parent');
+            expect(tree.isChildless()).toBe(true);
+        });
+
+        it('returns false if the node has any children', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild);
+
+            expect(tree.isChildless()).toBe(false);
+
+            tree.setRightChild(rightChild);
+
+            expect(tree.isChildless()).toBe(false);
+        });
+    });
+
+    describe('abandonChildren', () => {
+        it('unsets both children', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild, rightChild);
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+
+            tree.abandonChildren();
+
+            expect(tree.getLeftChild()).toBeNull();
+            expect(tree.getRightChild()).toBeNull();
+
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                ]
+            `);
+        });
+    });
+
+    describe('emancipate', () => {
+        it('does nothing if the node is a root node', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild, rightChild);
+
+            expect(tree.getParent()).toBeNull();
+            expect(tree.getChildType()).toBeNull();
+
+            tree.emancipate();
+
+            expect(tree.getParent()).toBeNull();
+            expect(tree.getChildType()).toBeNull();
+        });
+
+        it('renounces the parent for left children', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild, rightChild);
+
+            expect(leftChild.getParent()).toStrictEqual(tree);
+            expect(leftChild.getChildType()).toStrictEqual(ChildType.left);
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+
+            leftChild.emancipate();
+
+            expect(leftChild.getParent()).toBeNull();
+            expect(leftChild.getChildType()).toBeNull();
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "└──[R] right-child",
+                ]
+            `);
+        });
+
+        it('renounces the parent for right children', () => {
+            const leftChild = new BinTreeNode('left-child');
+            const rightChild = new BinTreeNode('right-child');
+            const tree = new BinTreeNode('parent', leftChild, rightChild);
+
+            expect(rightChild.getParent()).toStrictEqual(tree);
+            expect(rightChild.getChildType()).toStrictEqual(ChildType.right);
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "├──[L] left-child",
+                  "└──[R] right-child",
+                ]
+            `);
+
+            rightChild.emancipate();
+
+            expect(rightChild.getParent()).toBeNull();
+            expect(rightChild.getChildType()).toBeNull();
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "parent",
+                  "└──[L] left-child",
+                ]
+            `);
+        });
+    });
+});
+
+describe('cn', () => {
+    it('creates a new BinTreeNode', () => {
+        const tree = cn('root', cn('left'), cn('right'));
+        expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+            Array [
+              "root",
+              "├──[L] left",
+              "└──[R] right",
+            ]
+        `);
     });
 });

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/binHeaps.test.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/binHeaps.test.ts
@@ -1,5 +1,5 @@
 import { cn } from '../BinTreeNode';
-import { HeapType, insert, isValidHeap } from '../binHeaps';
+import { extract, HeapType, insert, isValidHeap } from '../binHeaps';
 import { getBinTreeDisplayLines } from '../binTreeDisplay';
 
 describe('isValidHeap', () => {
@@ -37,6 +37,112 @@ describe('isValidHeap', () => {
     });
 });
 
+describe('extract', () => {
+    [HeapType.max, HeapType.min].forEach((heapType) => {
+        const heapTypeName = HeapType[heapType];
+        describe(`both heap types`, () => {
+            it(`throws if the ${heapTypeName} heap is invalid`, () => {
+                const heap = cn(1, null, cn(3));
+                expect(() => {
+                    extract(heapType, heap);
+                }).toThrowErrorMatchingInlineSnapshot(
+                    `"Extract failed. Invalid ${heapTypeName} heap."`,
+                );
+            });
+
+            it('returns the heap as root and new heap if heap contains only one node', () => {
+                const heap = cn(1);
+
+                const [heapRoot, newHeap] = extract(heapType, heap);
+
+                expect(heapRoot).toStrictEqual(heap);
+                expect(newHeap).toStrictEqual(heap);
+            });
+
+            it('returns the root node and new heap when no reordering is necessary', () => {
+                const heap = cn(1, cn(1), cn(1));
+
+                const [heapRoot, newHeap] = extract(heapType, heap);
+
+                expect(heapRoot).toStrictEqual(cn(1));
+                expect(newHeap).toStrictEqual(cn(1, cn(1)));
+            });
+        });
+    });
+
+    describe(`max heap type`, () => {
+        const heapType = HeapType.max;
+
+        it('returns the root node and reordered tree', () => {
+            // Heap before
+            const heap = cn(7, cn(6, cn(4), cn(3)), cn(5, cn(2), cn(1)));
+            expect(getBinTreeDisplayLines(heap, true)).toMatchInlineSnapshot(`
+                Array [
+                  "7",
+                  "├──[L] 6",
+                  "│   ├──[L] 4",
+                  "│   └──[R] 3",
+                  "└──[R] 5",
+                  "    ├──[L] 2",
+                  "    └──[R] 1",
+                ]
+            `);
+
+            const [heapRoot, newHeap] = extract(heapType, heap);
+
+            // Expect root to be extracted, and tree to be reordered
+            expect(heapRoot).toStrictEqual(cn(7));
+            expect(getBinTreeDisplayLines(newHeap, true))
+                .toMatchInlineSnapshot(`
+                Array [
+                  "6",
+                  "├──[L] 4",
+                  "│   ├──[L] 1",
+                  "│   └──[R] 3",
+                  "└──[R] 5",
+                  "    └──[L] 2",
+                ]
+            `);
+        });
+    });
+
+    describe(`min heap type`, () => {
+        const heapType = HeapType.min;
+
+        it('returns the root node and reordered tree', () => {
+            // Heap before
+            const heap = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), cn(7)));
+            expect(getBinTreeDisplayLines(heap, true)).toMatchInlineSnapshot(`
+                Array [
+                  "1",
+                  "├──[L] 2",
+                  "│   ├──[L] 4",
+                  "│   └──[R] 5",
+                  "└──[R] 3",
+                  "    ├──[L] 6",
+                  "    └──[R] 7",
+                ]
+            `);
+
+            const [heapRoot, newHeap] = extract(heapType, heap);
+
+            // Expect root to be extracted, and tree to be reordered
+            expect(heapRoot).toStrictEqual(cn(1));
+            expect(getBinTreeDisplayLines(newHeap, true))
+                .toMatchInlineSnapshot(`
+                Array [
+                  "2",
+                  "├──[L] 4",
+                  "│   ├──[L] 7",
+                  "│   └──[R] 5",
+                  "└──[R] 3",
+                  "    └──[L] 6",
+                ]
+            `);
+        });
+    });
+});
+
 describe('insert', () => {
     describe('HeapType.max', () => {
         const heapType = HeapType.max;
@@ -51,9 +157,35 @@ describe('insert', () => {
                     cn(5, cn(2), cn(1)),
                 );
 
+                expect(getBinTreeDisplayLines(heap, true))
+                    .toMatchInlineSnapshot(`
+                    Array [
+                      "7",
+                      "├──[L] 6",
+                      "│   ├──[L] 4",
+                      "│   └──[R] 3",
+                      "└──[R] 5",
+                      "    ├──[L] 2",
+                      "    └──[R] 1",
+                    ]
+                `);
+
                 const actual = insert(heapType, heap, target);
 
                 expect(actual).toStrictEqual(expected);
+                expect(getBinTreeDisplayLines(actual, true))
+                    .toMatchInlineSnapshot(`
+                    Array [
+                      "7",
+                      "├──[L] 6.5",
+                      "│   ├──[L] 6",
+                      "│   │   └──[L] 4",
+                      "│   └──[R] 3",
+                      "└──[R] 5",
+                      "    ├──[L] 2",
+                      "    └──[R] 1",
+                    ]
+                `);
             });
 
             it('into the end of the heap (no swapping)', () => {

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/binTreeDisplay.test.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/binTreeDisplay.test.ts
@@ -32,6 +32,10 @@ const cousinTestBinTree = cn(
 );
 
 describe('getBinTreeDisplayLines', () => {
+    it('returns an empty list of display lines if the tree is null', () => {
+        expect(getBinTreeDisplayLines(null)).toMatchInlineSnapshot(`Array []`);
+    });
+
     it('returns display lines of a cousin chart binary tree', () => {
         expect(getBinTreeDisplayLines(cousinTestBinTree))
             .toMatchInlineSnapshot(`

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/binTreeUtils.test.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/__tests__/binTreeUtils.test.ts
@@ -1,6 +1,137 @@
 import { getBinTreeDisplayLines } from '../binTreeDisplay';
 import { cn } from '../BinTreeNode';
-import { appendToCompleteBinTree, isCompleteBinTree } from '../binTreeUtils';
+import {
+    appendToCompleteBinTree,
+    getLastNodeInCompleteBinTree,
+    isCompleteBinTree,
+    swapBinTreeNodes,
+} from '../binTreeUtils';
+
+describe('appendToCompleteBinTree', () => {
+    describe('typical states', () => {
+        it('appends a node into the leftmost slot in a new row', () => {
+            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), cn(7)));
+            const target = cn('🎯');
+            const expected = cn(
+                1,
+                cn(2, cn(4, target), cn(5)),
+                cn(3, cn(6), cn(7)),
+            );
+
+            appendToCompleteBinTree(tree, target);
+
+            expect(tree).toStrictEqual(expected);
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "1",
+                  "├──[L] 2",
+                  "│   ├──[L] 4",
+                  "│   │   └──[L] 🎯",
+                  "│   └──[R] 5",
+                  "└──[R] 3",
+                  "    ├──[L] 6",
+                  "    └──[R] 7",
+                ]
+            `);
+        });
+
+        it('appends a node into the rightmost slot in a nearly-complete row', () => {
+            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6)));
+            const target = cn('🎯');
+            const expected = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), target));
+
+            appendToCompleteBinTree(tree, target);
+
+            expect(tree).toStrictEqual(expected);
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "1",
+                  "├──[L] 2",
+                  "│   ├──[L] 4",
+                  "│   └──[R] 5",
+                  "└──[R] 3",
+                  "    ├──[L] 6",
+                  "    └──[R] 🎯",
+                ]
+            `);
+        });
+
+        it('appends a node into the middle slot of the last row', () => {
+            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3));
+            const target = cn('🎯');
+            const expected = cn(1, cn(2, cn(4), cn(5)), cn(3, target));
+
+            appendToCompleteBinTree(tree, target);
+
+            expect(tree).toStrictEqual(expected);
+            expect(getBinTreeDisplayLines(tree, true)).toMatchInlineSnapshot(`
+                Array [
+                  "1",
+                  "├──[L] 2",
+                  "│   ├──[L] 4",
+                  "│   └──[R] 5",
+                  "└──[R] 3",
+                  "    └──[L] 🎯",
+                ]
+            `);
+        });
+    });
+
+    it('inserts the target into an empty tree', () => {
+        const tree = null;
+        const target = cn('🎯');
+        const expected = target;
+
+        const actual = appendToCompleteBinTree(tree, target);
+
+        expect(actual).toStrictEqual(expected);
+        expect(getBinTreeDisplayLines(target, true)).toMatchInlineSnapshot(`
+            Array [
+              "🎯",
+            ]
+        `);
+    });
+
+    describe('error states', () => {
+        it("throws if tree isn't complete", () => {
+            const tree = cn(1, cn(2, cn(4)), cn(3, cn(6), cn(7)));
+            const target = cn('🎯');
+            expect(() => {
+                appendToCompleteBinTree(tree, target);
+            }).toThrowErrorMatchingInlineSnapshot(
+                `"Binary tree must be \\"complete\\""`,
+            );
+        });
+
+        it("throws if target isn't childless", () => {
+            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), cn(7)));
+            const target = cn('parent', cn('left-child'), cn('right-child'));
+            expect(() => {
+                appendToCompleteBinTree(tree, target);
+            }).toThrowErrorMatchingInlineSnapshot(
+                `"Target node must be childless"`,
+            );
+        });
+    });
+});
+
+describe('getLastNodeInCompleteBinTree', () => {
+    it('returns null for an empty tree', () => {
+        expect(getLastNodeInCompleteBinTree(null)).toBe(null);
+    });
+
+    it('finds the last node in a perfect tree', () => {
+        const lastNode = cn(7);
+        const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), lastNode));
+        expect(getLastNodeInCompleteBinTree(tree)).toEqual(lastNode);
+    });
+
+    it('finds the last node in an imperfect tree', () => {
+        const lastNode = cn(6);
+        const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, lastNode));
+        expect(getLastNodeInCompleteBinTree(tree)).toEqual(lastNode);
+    });
+});
 
 describe('isCompleteBinTree', () => {
     it('returns true for empty trees', () => {
@@ -29,72 +160,91 @@ describe('isCompleteBinTree', () => {
     });
 });
 
-describe('appendToCompleteBinTree', () => {
-    describe('typical states', () => {
-        it('appends a node into the leftmost slot in a new row', () => {
-            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), cn(7)));
-            const target = cn('🎯');
-            const expected = cn(
-                1,
-                cn(2, cn(4, target), cn(5)),
-                cn(3, cn(6), cn(7)),
-            );
+describe('swapBinTreeNodes', () => {
+    it('swaps two nodes in a binary tree', () => {
+        const nodeA = cn(4);
+        const nodeB = cn(7);
+        const actualTree = cn(1, cn(2, nodeA, cn(5)), cn(3, cn(6), nodeB));
+        const expectedTree = cn(1, cn(2, cn(7), cn(5)), cn(3, cn(6), cn(4)));
 
-            appendToCompleteBinTree(tree, target);
+        swapBinTreeNodes(nodeA, nodeB);
 
-            expect(tree).toStrictEqual(expected);
-        });
-
-        it('appends a node into the rightmost slot in a nearly-complete row', () => {
-            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6)));
-            const target = cn('🎯');
-            const expected = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), target));
-
-            appendToCompleteBinTree(tree, target);
-
-            expect(tree).toStrictEqual(expected);
-        });
-
-        it('appends a node into the middle slot of the last row', () => {
-            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3));
-            const target = cn('🎯');
-            const expected = cn(1, cn(2, cn(4), cn(5)), cn(3, target));
-
-            appendToCompleteBinTree(tree, target);
-
-            expect(tree).toStrictEqual(expected);
-        });
+        expect(actualTree).toStrictEqual(expectedTree);
+        expect(getBinTreeDisplayLines(actualTree, true)).toMatchInlineSnapshot(`
+            Array [
+              "1",
+              "├──[L] 2",
+              "│   ├──[L] 7",
+              "│   └──[R] 5",
+              "└──[R] 3",
+              "    ├──[L] 6",
+              "    └──[R] 4",
+            ]
+        `);
     });
 
-    it('inserts the target into an empty tree', () => {
-        const tree = null;
-        const target = cn('🎯');
-        const expected = target;
+    it('swaps two nodes on different levels', () => {
+        const nodeA = cn(2, cn(4), cn(5));
+        const nodeB = cn(7);
+        const actualTree = cn(1, nodeA, cn(3, cn(6), nodeB));
+        const expectedTree = cn(1, cn(7, cn(4), cn(5)), cn(3, cn(6), cn(2)));
 
-        const actual = appendToCompleteBinTree(tree, target);
+        swapBinTreeNodes(nodeA, nodeB);
 
-        expect(actual).toStrictEqual(expected);
+        expect(actualTree).toStrictEqual(expectedTree);
+        expect(getBinTreeDisplayLines(actualTree, true)).toMatchInlineSnapshot(`
+            Array [
+              "1",
+              "├──[L] 7",
+              "│   ├──[L] 4",
+              "│   └──[R] 5",
+              "└──[R] 3",
+              "    ├──[L] 6",
+              "    └──[R] 2",
+            ]
+        `);
     });
 
-    describe('error states', () => {
-        it("throws if tree isn't complete", () => {
-            const tree = cn(1, cn(2, cn(4)), cn(3, cn(6), cn(7)));
-            const target = cn('🎯');
-            expect(() => {
-                appendToCompleteBinTree(tree, target);
-            }).toThrowErrorMatchingInlineSnapshot(
-                `"Binary tree must be \\"complete\\""`,
-            );
-        });
+    it('swaps direct ancestors', () => {
+        const nodeB = cn(7);
+        const nodeA = cn(3, cn(6), nodeB);
+        const actualTree = cn(1, cn(2, cn(4), cn(5)), nodeA);
+        const expectedTree = cn(1, cn(2, cn(4), cn(5)), cn(7, cn(6), cn(3)));
 
-        it("throws if target isn't childless", () => {
-            const tree = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), cn(7)));
-            const target = cn('parent', cn('left-child'), cn('right-child'));
-            expect(() => {
-                appendToCompleteBinTree(tree, target);
-            }).toThrowErrorMatchingInlineSnapshot(
-                `"Target node must be childless"`,
-            );
-        });
+        swapBinTreeNodes(nodeA, nodeB);
+
+        expect(actualTree).toStrictEqual(expectedTree);
+        expect(getBinTreeDisplayLines(actualTree, true)).toMatchInlineSnapshot(`
+            Array [
+              "1",
+              "├──[L] 2",
+              "│   ├──[L] 4",
+              "│   └──[R] 5",
+              "└──[R] 7",
+              "    ├──[L] 6",
+              "    └──[R] 3",
+            ]
+        `);
+    });
+
+    it('swaps with the root node', () => {
+        const nodeA = cn(7);
+        const nodeB = cn(1, cn(2, cn(4), cn(5)), cn(3, cn(6), nodeA));
+        const expectedTree = cn(7, cn(2, cn(4), cn(5)), cn(3, cn(6), cn(1)));
+
+        swapBinTreeNodes(nodeA, nodeB);
+
+        expect(nodeA).toStrictEqual(expectedTree);
+        expect(getBinTreeDisplayLines(nodeA, true)).toMatchInlineSnapshot(`
+            Array [
+              "7",
+              "├──[L] 2",
+              "│   ├──[L] 4",
+              "│   └──[R] 5",
+              "└──[R] 3",
+              "    ├──[L] 6",
+              "    └──[R] 1",
+            ]
+        `);
     });
 });

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/binTreeDisplay.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/binTreeDisplay.ts
@@ -49,6 +49,11 @@ export const getBinTreeDisplayLines = (
     // Lines of the display to return
     const lines: (number | string)[] = [];
 
+    // Nothing to display if the tree is null
+    if (!binTreeRoot) {
+        return lines;
+    }
+
     // Stack of nodes to search, keeping track of levels and sibling
     // status. Begin with the tree root.
     const searchStack: BTSearchStackNode[] = [
@@ -105,10 +110,10 @@ export const getBinTreeDisplayLines = (
             // Add a left (L) or a right (R) label to show what kind of a child
             // this is
             if (showLeftRightLabel) {
-                if (BTNode.childType === ChildType.left) {
+                if (BTNode.getChildType() === ChildType.left) {
                     linePrefix += prefixLabelLeft;
                 }
-                if (BTNode.childType === ChildType.right) {
+                if (BTNode.getChildType() === ChildType.right) {
                     linePrefix += prefixLabelRight;
                 }
             } else {

--- a/src/ctci-6th-ed/ch04_trees-and-graphs/binTreeUtils.ts
+++ b/src/ctci-6th-ed/ch04_trees-and-graphs/binTreeUtils.ts
@@ -1,6 +1,102 @@
 // This file contains common binary tree utilities
 
-import BinTreeNode from './BinTreeNode';
+import { getBinTreeDisplayLines } from './binTreeDisplay';
+import BinTreeNode, { ChildType } from './BinTreeNode';
+
+/**
+ * Insert a node into the bottom-rightmost position of a complete binary tree
+ * IN-PLACE.
+ *
+ * @param completeBinTree   The complete binary tree in which to insert the
+ *                          target node. WARNING: This will be modified.
+ * @param target            The node to insert into the tree. Must be childness.
+ */
+export const appendToCompleteBinTree = (
+    completeBinTree: BinTreeNode,
+    target: BinTreeNode,
+): BinTreeNode => {
+    if (!isCompleteBinTree(completeBinTree)) {
+        throw new Error('Binary tree must be "complete"');
+    }
+
+    if (!target.isChildless()) {
+        throw new Error('Target node must be childless');
+    }
+
+    // If the bin tree is null, just return the target
+    if (!completeBinTree) {
+        return target;
+    }
+
+    // Breath-first search the binary tree and insert the target node into the
+    // first empty position
+    const searchQueue: BinTreeNode[] = [completeBinTree];
+    while (searchQueue.length > 0) {
+        const curNode = searchQueue.pop();
+        const rightChild = curNode.getRightChild();
+        const leftChild = curNode.getLeftChild();
+
+        // If we encounter an empty left child, insert the target immediately
+        if (leftChild) {
+            searchQueue.unshift(leftChild);
+        } else {
+            curNode.setLeftChild(target);
+            break;
+        }
+
+        // If we encounter an empty right child, insert the target there,
+        // unless the left child is also empty, in which case we'll insert it
+        // there instead
+        if (rightChild) {
+            searchQueue.unshift(rightChild);
+        } else {
+            if (!leftChild) {
+                curNode.setLeftChild(target);
+            } else {
+                curNode.setRightChild(target);
+            }
+            break;
+        }
+    }
+
+    return completeBinTree;
+};
+
+/**
+ * Return the last node in a complete binary tree, i.e., the bottom-rightmost
+ */
+export const getLastNodeInCompleteBinTree = (
+    completeBinTree: BinTreeNode,
+): BinTreeNode => {
+    if (!completeBinTree) {
+        return null;
+    }
+
+    if (!isCompleteBinTree(completeBinTree)) {
+        throw new Error('Binary tree must be "complete"');
+    }
+
+    // Breath-first search through the tree until we find the last node
+    let lastNode = completeBinTree;
+    const searchQueue: BinTreeNode[] = [completeBinTree];
+    while (searchQueue.length > 0) {
+        const curNode = searchQueue.pop();
+        const leftChild = curNode.getLeftChild();
+        const rightChild = curNode.getRightChild();
+
+        lastNode = curNode;
+
+        if (leftChild) {
+            searchQueue.unshift(leftChild);
+        }
+
+        if (rightChild) {
+            searchQueue.unshift(rightChild);
+        }
+    }
+
+    return lastNode;
+};
 
 /**
  * Returns if a binary tree is "complete", i.e., a binary tree that is
@@ -50,60 +146,87 @@ export const isCompleteBinTree = (binTree: BinTreeNode): boolean => {
 };
 
 /**
- * Insert a node into the bottom-rightmost position of a complete binary tree
- * IN-PLACE.
+ * Swap two nodes in a binary tree, i.e., their children and parents
  *
- * @param completeBinTree   The complete binary tree in which to insert the
- *                          target node. WARNING: This will be modified.
- * @param target            The node to insert into the tree. Must be childness.
+ * @param nodeA
+ * @param nodeB
  */
-export const appendToCompleteBinTree = (
-    completeBinTree: BinTreeNode,
-    target: BinTreeNode,
-): BinTreeNode => {
-    if (!isCompleteBinTree(completeBinTree)) {
-        throw new Error('Binary tree must be "complete"');
+export const swapBinTreeNodes = (
+    nodeA: BinTreeNode,
+    nodeB: BinTreeNode,
+): void => {
+    // Capture references to both nodes' relatives so we don't have to worry
+    // about the order, or overwriting them as we swap
+    const relA = {
+        parent: nodeA.getParent(),
+        childType: nodeA.getChildType(),
+        leftChild: nodeA.getLeftChild(),
+        rightChild: nodeA.getRightChild(),
+    };
+    const relB = {
+        parent: nodeB.getParent(),
+        childType: nodeB.getChildType(),
+        leftChild: nodeB.getLeftChild(),
+        rightChild: nodeB.getRightChild(),
+    };
+
+    // Abandon their children to make room for adopting the other's
+    nodeA.abandonChildren();
+    nodeB.abandonChildren();
+
+    // A adopts B's children if it has any
+    if (relB.leftChild) {
+        nodeA.setLeftChild(relB.leftChild);
+    }
+    if (relB.rightChild) {
+        nodeA.setRightChild(relB.rightChild);
     }
 
-    if (!target.isChildless()) {
-        throw new Error('Target node must be childless');
+    // B adopts A's children if it has any
+    if (relA.leftChild) {
+        nodeB.setLeftChild(relA.leftChild);
+    }
+    if (relA.rightChild) {
+        nodeB.setRightChild(relA.rightChild);
     }
 
-    // If the bin tree is null, just return the target
-    if (!completeBinTree) {
-        return target;
-    }
+    // Renounce their parents so they can be adopted by the other
+    nodeA.emancipate();
+    nodeB.emancipate();
 
-    // Breath-first search the binary tree and insert the target node into the
-    // first empty position
-    const searchStack: BinTreeNode[] = [completeBinTree];
-    while (searchStack.length > 0) {
-        const curNode = searchStack.pop();
-        const rightChild = curNode.getRightChild();
-        const leftChild = curNode.getLeftChild();
-
-        // If we encounter an empty left child, insert the target immediately
-        if (leftChild) {
-            searchStack.unshift(leftChild);
-        } else {
-            curNode.setLeftChild(target);
-            break;
-        }
-
-        // If we encounter an empty right child, insert the target there,
-        // unless the left child is also empty, in which case we'll insert it
-        // there instead
-        if (rightChild) {
-            searchStack.unshift(rightChild);
-        } else {
-            if (!leftChild) {
-                curNode.setLeftChild(target);
+    // Reparent A: B's parent adopts A if it's not the root, unless A is the
+    // parent, in which case make B the parent of A
+    if (relB.parent) {
+        if (relB.childType === ChildType.left) {
+            if (relB.parent !== nodeA) {
+                relB.parent.setLeftChild(nodeA);
             } else {
-                curNode.setRightChild(target);
+                nodeB.setLeftChild(nodeA);
             }
-            break;
+        } else if (relB.childType === ChildType.right) {
+            if (relB.parent !== nodeA) {
+                relB.parent.setRightChild(nodeA);
+            } else {
+                nodeB.setRightChild(nodeA);
+            }
         }
     }
 
-    return completeBinTree;
+    // Reparent B: A's parent adopts B if it's not the root, unless B is the
+    // parent, in which case make A the parent of B
+    if (relA.parent) {
+        if (relA.childType === ChildType.left) {
+            if (relA.parent !== nodeB) {
+                relA.parent.setLeftChild(nodeB);
+            } else {
+                nodeA.setLeftChild(nodeB);
+            }
+        } else if (relA.childType === ChildType.right) {
+            if (relA.parent !== nodeB) {
+                relA.parent.setRightChild(nodeB);
+            } else {
+                nodeA.setRightChild(nodeB);
+            }
+        }
+    }
 };


### PR DESCRIPTION
- Functions for heaps:
    - Add `extract`
    - Update `insert`
- Add binary tree utility functions:
    - `appendToCompleteBinTree`
    - `getLastNodeInCompleteBinTree`
    - `swapBinTreeNodes`
- Update BinTreeNode class to be more robust, only allow modification of
  children
- Fix binTreeDisplay to account for null trees
- Update unit tests